### PR TITLE
Allow the user to edit the Dag / Block doc styles.

### DIFF
--- a/src/sier2/_block.py
+++ b/src/sier2/_block.py
@@ -145,7 +145,7 @@ class Block(param.Parameterized):
 
     SIER2_KEY = '_sier2__key'
 
-    def __init__(self, *args, wait_for_input: bool=False, visible: bool=True, doc: str|None=None, display_options: list[str]|dict[str, Any]|None=None, only_in=False, continue_label='Continue', **kwargs):
+    def __init__(self, *args, wait_for_input: bool=False, visible: bool=True, doc: str|None=None, doc_styles: dict|None=None, display_options: list[str]|dict[str, Any]|None=None, only_in=False, continue_label='Continue', **kwargs):
         """
         Parameters
         ----------
@@ -155,6 +155,8 @@ class Block(param.Parameterized):
             If True (the default), the block will be visible in a GUI.
         doc: str|None
             Markdown documentation that may displayed in the user interface.
+        doc_styles: dict|None
+            Style for the markdown documentation
         display_options: list[str]|dict[str, Any]|None
             Display options to be used when displaying this block in a GUI.
         only_in: bool
@@ -174,6 +176,7 @@ class Block(param.Parameterized):
         self._wait_for_input = wait_for_input
         self._visible = visible
         self.doc = doc
+        self.doc_styles = doc_styles
         self.display_options = display_options
         self.only_in = only_in
         self.continue_label = continue_label

--- a/src/sier2/_dag.py
+++ b/src/sier2/_dag.py
@@ -190,7 +190,7 @@ _RESTART = ':restart:'
 class Dag:
     """A directed acyclic graph of blocks."""
 
-    def __init__(self, *, site: str='Block', title: str, doc: str, author: dict[str, str]=None, show_doc: bool=True):
+    def __init__(self, *, site: str='Block', title: str, doc: str, style: dict[str, str]=None, author: dict[str, str]=None, show_doc: bool=True):
         """A new dag.
 
         Parameters
@@ -201,6 +201,8 @@ class Dag:
             A title to show in the header.
         doc: str
             Dag documentation.
+        style: dict
+            Dag documentation custom style.
         author: str
             The dag author.
         show_doc: bool
@@ -220,6 +222,7 @@ class Dag:
         self.site = site
         self.title = title
         self.doc = doc
+        self.style = style
         self.show_doc = show_doc
 
         if author is not None:

--- a/src/sier2/panel/_panel.py
+++ b/src/sier2/panel/_panel.py
@@ -257,6 +257,7 @@ def _prepare_to_show(dag: Dag):
         )
 
         card = pn.Card(pn.pane.Markdown(doc, sizing_mode='stretch_width'), header=pn.Row(name_text), sizing_mode='stretch_width')
+        card[0].styles = dag.style if dag.style else {}
         cards.append(card)
 
     cards.extend(BlockCard(parent_template=template, dag=dag, block=gw, dag_logger=dag_logger) for gw in dag.get_sorted() if gw._visible)
@@ -313,6 +314,11 @@ class BlockCard(pn.Card):
         #
         doc = pn.pane.Markdown(block.doc, sizing_mode='scale_width') if block.doc else None
 
+        # if the block has documentation, has the user specified a style for the markdown?
+        # 
+        if doc is not None and w.doc_styles is not None:
+          doc.styles = w.doc_styles
+          
         if block._wait_for_input:
             # This is an input block, so add a 'Continue' button.
             #


### PR DESCRIPTION
It would be useful if the user can edit the Dag and/or Block's documentation style parameter.

An implementation of this is included in this pull request. It may also be useful in the future to change the DAG doc from a statictext to  pn.pane.markdown to allow the use of __repr__ markdown's.